### PR TITLE
🐛 Fix mautic 6 contact segment and tag tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Project Overview
+
+This is Helio's local fork of a Mautic MCP server. Team members clone it locally and point Codex or Claude at the built `build/index.js` entrypoint.
+
+This repository is not currently deployed as a package or service. Keep the workflow lightweight and optimized for local MCP use.
+
+## Compatibility
+
+- Tested target: Mautic 6.0.7.
+- Keep existing API v2 / Mautic 7 code untouched unless the user explicitly asks to work on it.
+- Prefer fixing Mautic 6.0.7 compatibility in the v1/FOSRestBundle paths when possible.
+- Before changing request payload shapes, verify Mautic field aliases and endpoint expectations. The Mautic UI labels do not always match API field names.
+
+## Local Commands
+
+Use npm for the canonical commands:
+
+```sh
+npm install
+npm run check
+npm run build
+```
+
+If `just` is available, these wrappers are also supported:
+
+```sh
+just check
+just build
+just ready
+```
+
+## Completion Rules
+
+Before calling code work complete:
+
+1. Run `npm run check`.
+2. Run `npm run build`.
+3. If MCP behavior changed, remind the user to restart the Codex or Claude MCP server so it loads the rebuilt `build/index.js`.
+
+For documentation-only changes, `npm run check` and `npm run build` are optional unless package scripts, TypeScript config, or generated output may have been affected.
+
+## Versioning
+
+Versioning is manual for now.
+
+- Update `package.json`, `package-lock.json`, and `CHANGELOG.md` together when behavior changes.
+- Use patch versions for bug fixes, such as `0.1.1`.
+- Use minor versions for new tools or meaningful MCP behavior, such as `0.2.0`.
+- Tags such as `v0.1.0` or `local-YYYY-MM-DD` may be used as known-good local checkpoints.
+
+Do not add release automation, package publishing, or secret-based versioning unless the user explicitly asks for it.
+
+## Change Scope
+
+- Keep `main` stable.
+- Use branches or PRs for fixes.
+- Keep changes narrowly scoped to the MCP behavior requested.
+- Do not perform the contact API audit fixes unless the user explicitly resumes that audit work.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Established this as Helio's local Mautic MCP fork.
+- Documented Mautic 6.0.7 as the tested compatibility target.
+- Documented that API v2 / Mautic 7 code should be left untouched unless explicitly required.
+- Fixed contact first and last name updates by mapping MCP `firstName` / `lastName` input to Mautic contact field aliases.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
 
+## 0.1.1
+
+- Fixed `get_segment_contacts` for Mautic 6.0.7 by resolving the segment alias and using contact search with `segment:<alias>`.
+- Added normalized contact output for `get_contact`, `search_contacts`, and `get_segment_contacts`.
+- Added optional field alias filtering for compact contact responses.
+- Preserved explicit `0` and `false` query parameters in audited v1 contact, segment, and business tools.
+- Switched contact tag add/remove operations to the v1 contact edit endpoint pattern; live verification still requires a disposable test contact.
+
 ## 0.1.0
 
 - Established this as Helio's local Mautic MCP fork.
 - Documented Mautic 6.0.7 as the tested compatibility target.
 - Documented that API v2 / Mautic 7 code should be left untouched unless explicitly required.
 - Fixed contact first and last name updates by mapping MCP `firstName` / `lastName` input to Mautic contact field aliases.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,52 @@
 # Mautic MCP Server
 
-A comprehensive Model Context Protocol (MCP) server for Mautic 7 (Columba Edition) marketing automation platform. Supports both v1 (FOSRestBundle) and v2 (API Platform) endpoints with 68 tools.
+Helio's local Model Context Protocol (MCP) server fork for Mautic. The fork is cloned locally by team members and used directly by Codex and Claude.
+
+Compatibility target: tested with Mautic 6.0.7.
+
+API v2 / Mautic 7 code is preserved from upstream and should be left untouched unless explicitly required.
+
+## Helio Local Workflow
+
+Keep `main` stable. Codex and Claude should point at `main` or a known-good tag.
+
+Use a branch for each fix, run the build before merging, then restart the local MCP process in Codex or Claude.
+
+```bash
+npm install
+npm run build
+```
+
+If `just` is available, the same local checks are:
+
+```bash
+just ready
+```
+
+After pulling changes, always rebuild and restart the MCP server. Pulling code is not enough if Codex or Claude still has the old `build/index.js` process running.
+
+Example local MCP command:
+
+```json
+{
+  "command": "node",
+  "args": ["/Users/jamesriggleman/code/helio-additive/helio-mautic-MCP/build/index.js"]
+}
+```
+
+## Versioning
+
+This fork uses lightweight local versioning:
+
+- `0.1.x` for bug fixes.
+- `0.2.x` for new tools or behavior.
+- Tags such as `local-2026-07-16` or `v0.1.0` mark known-good checkpoints.
+
+See [CHANGELOG.md](CHANGELOG.md) for local compatibility notes.
+
+## Upstream Context
+
+This fork started from a comprehensive Model Context Protocol (MCP) server for Mautic 7 (Columba Edition) marketing automation platform. Supports both v1 (FOSRestBundle) and v2 (API Platform) endpoints with 68 tools.
 
 [![GitHub Stars](https://img.shields.io/github/stars/Cbrown35/mantic-MCP?style=social)](https://github.com/Cbrown35/mantic-MCP/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/Cbrown35/mantic-MCP)](https://github.com/Cbrown35/mantic-MCP/issues)
@@ -9,9 +55,9 @@ A comprehensive Model Context Protocol (MCP) server for Mautic 7 (Columba Editio
 ## Quick Start
 
 ```bash
-# Clone and setup
-git clone https://github.com/Cbrown35/mantic-MCP.git
-cd mantic-MCP
+# Clone and setup the Helio fork
+git clone <helio-fork-url>
+cd helio-mautic-MCP
 npm install
 
 # Configure your Mautic credentials
@@ -28,7 +74,7 @@ Then add the server to your MCP configuration and start using natural language c
 - "Clone campaign 5 and export it for staging"
 - "Send email template 12 to its assigned segment"
 
-## What's New in v2.0 (Mautic 7 Support)
+## Upstream v2.0 Notes (Mautic 7 Support)
 
 ### Projects (API v2)
 Organize marketing resources under a single logical structure using Mautic 7's new API Platform v2 endpoints.
@@ -155,14 +201,14 @@ SMS API classes have been removed in Mautic 7. The `list_sms` and `create_sms` t
 ### Prerequisites
 - Node.js (v16 or higher)
 - npm or yarn
-- Access to a Mautic 7 instance with API credentials
+- Access to a Mautic instance with API credentials. Helio tests this fork against Mautic 6.0.7.
 
 ### Setup
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/Cbrown35/mantic-MCP.git
-   cd mantic-MCP
+   git clone <helio-fork-url>
+   cd helio-mautic-MCP
    ```
 
 2. **Install dependencies:**

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+install:
+    npm install
+
+check:
+    npm run check
+
+build:
+    npm run build
+
+ready:
+    npm install
+    npm run build
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "mantic.dzind",
-  "version": "2.0.0",
+  "name": "helio-mautic-mcp",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mantic.dzind",
-      "version": "2.0.0",
+      "name": "helio-mautic-mcp",
+      "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "axios": "^1.10.0"
       },
       "bin": {
-        "mantic.dzind": "build/index.js"
+        "helio-mautic-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helio-mautic-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helio-mautic-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "axios": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
-  "name": "mantic.dzind",
-  "version": "2.0.0",
-  "description": "A Model Context Protocol server for Mautic 7 (Columba Edition) marketing automation",
+  "name": "helio-mautic-mcp",
+  "version": "0.1.0",
+  "description": "Helio local fork of a Mautic MCP server, tested with Mautic 6.0.7",
   "private": true,
   "type": "module",
   "bin": {
-    "mantic.dzind": "./build/index.js"
+    "helio-mautic-mcp": "./build/index.js"
   },
   "files": [
     "build"
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "check": "tsc --noEmit",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helio-mautic-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Helio local fork of a Mautic MCP server, tested with Mautic 6.0.7",
   "private": true,
   "type": "module",

--- a/src/tools/business.ts
+++ b/src/tools/business.ts
@@ -1,5 +1,6 @@
 import type { MauticApiClient } from '../api/client.js';
 import type { ToolDefinition, ToolHandler } from '../types/index.js';
+import { normalizeContact, setLimitedParam, setParam } from './utils.js';
 
 export const toolDefinitions: ToolDefinition[] = [
   {
@@ -96,12 +97,24 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'add_contact_tags',
-    description: 'Add tags to contact',
+    description: 'Add tags to contact using the Mautic v1 contact edit endpoint',
     inputSchema: {
       type: 'object',
       properties: {
         contactId: { type: 'number', description: 'Contact ID' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Array of tag names' },
+      },
+      required: ['contactId', 'tags'],
+    },
+  },
+  {
+    name: 'remove_contact_tags',
+    description: 'Remove tags from contact using the Mautic v1 contact edit endpoint',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contactId: { type: 'number', description: 'Contact ID' },
+        tags: { type: 'array', items: { type: 'string' }, description: 'Array of tag names to remove' },
       },
       required: ['contactId', 'tags'],
     },
@@ -137,9 +150,9 @@ export const toolDefinitions: ToolDefinition[] = [
 export const toolHandlers: Record<string, ToolHandler> = {
   async list_companies(client: MauticApiClient, args: any) {
     const params: any = {};
-    if (args?.search) params.search = args.search;
-    if (args?.limit) params.limit = Math.min(args.limit, 200);
-    if (args?.start) params.start = args.start;
+    setParam(params, 'search', args?.search);
+    setLimitedParam(params, 'limit', args?.limit, 200);
+    setParam(params, 'start', args?.start);
 
     const response = await client.v1.get('/companies', { params });
     return {
@@ -164,8 +177,8 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   async create_note(client: MauticApiClient, args: any) {
     const payload: any = { text: args.text, type: args.type || 'general' };
-    if (args.contactId) payload.contact = args.contactId;
-    if (args.companyId) payload.company = args.companyId;
+    setParam(payload, 'contact', args.contactId);
+    setParam(payload, 'company', args.companyId);
 
     const response = await client.v1.post('/notes/new', payload);
     return {
@@ -176,7 +189,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
   async get_contact_notes(client: MauticApiClient, args: any) {
     const { contactId, limit } = args;
     const params: any = {};
-    if (limit) params.limit = Math.min(limit, 200);
+    setLimitedParam(params, 'limit', limit, 200);
 
     const response = await client.v1.get(`/contacts/${contactId}/notes`, { params });
     return {
@@ -186,8 +199,8 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   async list_tags(client: MauticApiClient, args: any) {
     const params: any = {};
-    if (args?.search) params.search = args.search;
-    if (args?.limit) params.limit = Math.min(args.limit, 200);
+    setParam(params, 'search', args?.search);
+    setLimitedParam(params, 'limit', args?.limit, 200);
 
     const response = await client.v1.get('/tags', { params });
     return {
@@ -204,16 +217,26 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   async add_contact_tags(client: MauticApiClient, args: any) {
     const { contactId, tags } = args;
-    const response = await client.v1.post(`/contacts/${contactId}/contact/add`, { tags });
+    const response = await client.v1.patch(`/contacts/${contactId}/edit`, { tags: tags.join(',') });
     return {
-      content: [{ type: 'text', text: `Tags added to contact ${contactId} successfully:\n${JSON.stringify(response.data, null, 2)}` }],
+      content: [{ type: 'text', text: `Tags added to contact ${contactId} successfully:\n${JSON.stringify(normalizeContact(response.data.contact), null, 2)}` }],
+    };
+  },
+
+  async remove_contact_tags(client: MauticApiClient, args: any) {
+    const { contactId, tags } = args;
+    const response = await client.v1.patch(`/contacts/${contactId}/edit`, {
+      tags: tags.map((tag: string) => `-${tag}`).join(','),
+    });
+    return {
+      content: [{ type: 'text', text: `Tags removed from contact ${contactId} successfully:\n${JSON.stringify(normalizeContact(response.data.contact), null, 2)}` }],
     };
   },
 
   async list_categories(client: MauticApiClient, args: any) {
     const params: any = {};
-    if (args?.bundle) params.bundle = args.bundle;
-    if (args?.limit) params.limit = Math.min(args.limit, 200);
+    setParam(params, 'bundle', args?.bundle);
+    setLimitedParam(params, 'limit', args?.limit, 200);
 
     const response = await client.v1.get('/categories', { params });
     return {

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { MauticApiClient } from '../api/client.js';
 import type { ToolDefinition, ToolHandler } from '../types/index.js';
+import { normalizeContact, normalizeContacts, setLimitedParam, setParam } from './utils.js';
 
 function buildContactPayload(args: any) {
   const { firstName, lastName, customFields, ...rest } = args;
@@ -26,7 +27,7 @@ export const toolDefinitions: ToolDefinition[] = [
         phone: { type: 'string', description: 'Phone number' },
         company: { type: 'string', description: 'Company name' },
         position: { type: 'string', description: 'Job position' },
-        customFields: { type: 'object', description: 'Custom field values' },
+        customFields: { type: 'object', description: 'Custom field values keyed by Mautic field alias' },
       },
       required: ['email'],
     },
@@ -44,7 +45,7 @@ export const toolDefinitions: ToolDefinition[] = [
         phone: { type: 'string', description: 'Phone number' },
         company: { type: 'string', description: 'Company name' },
         position: { type: 'string', description: 'Job position' },
-        customFields: { type: 'object', description: 'Custom field values' },
+        customFields: { type: 'object', description: 'Custom field values keyed by Mautic field alias' },
       },
       required: ['id'],
     },
@@ -57,6 +58,9 @@ export const toolDefinitions: ToolDefinition[] = [
       properties: {
         id: { type: 'number', description: 'Contact ID' },
         email: { type: 'string', description: 'Contact email address' },
+        minimal: { type: 'boolean', description: 'Return normalized contact data instead of full Mautic metadata' },
+        fieldsOnly: { type: 'boolean', description: 'Return only normalized contact field values plus id' },
+        fields: { type: 'array', items: { type: 'string' }, description: 'Field aliases to include when minimal or fieldsOnly is true' },
       },
     },
   },
@@ -72,7 +76,9 @@ export const toolDefinitions: ToolDefinition[] = [
         orderBy: { type: 'string', description: 'Field to order by' },
         orderByDir: { type: 'string', enum: ['ASC', 'DESC'], description: 'Order direction' },
         publishedOnly: { type: 'boolean', description: 'Only published contacts' },
-        minimal: { type: 'boolean', description: 'Return minimal contact data' },
+        minimal: { type: 'boolean', description: 'Return normalized contact data instead of full Mautic metadata' },
+        fieldsOnly: { type: 'boolean', description: 'Return only normalized contact field values plus id' },
+        fields: { type: 'array', items: { type: 'string' }, description: 'Field aliases to include when minimal or fieldsOnly is true' },
       },
     },
   },
@@ -118,10 +124,10 @@ export const toolHandlers: Record<string, ToolHandler> = {
   },
 
   async get_contact(client: MauticApiClient, args: any) {
-    const { id, email } = args;
+    const { id, email, minimal, fieldsOnly, fields } = args;
     let response;
 
-    if (id) {
+    if (id !== undefined) {
       response = await client.v1.get(`/contacts/${id}`);
     } else if (email) {
       const searchResponse = await client.v1.get('/contacts', {
@@ -136,24 +142,36 @@ export const toolHandlers: Record<string, ToolHandler> = {
       throw new McpError(ErrorCode.InvalidParams, 'Either id or email must be provided');
     }
 
+    const contact = response.data.contact;
+    const output = fieldsOnly
+      ? { id: contact?.id, fields: normalizeContact(contact, fields).fields }
+      : minimal
+        ? normalizeContact(contact, fields)
+        : contact;
+
     return {
-      content: [{ type: 'text', text: `Contact details:\n${JSON.stringify(response.data.contact, null, 2)}` }],
+      content: [{ type: 'text', text: `Contact details:\n${JSON.stringify(output, null, 2)}` }],
     };
   },
 
   async search_contacts(client: MauticApiClient, args: any) {
     const params: any = {};
-    if (args?.search) params.search = args.search;
-    if (args?.limit) params.limit = Math.min(args.limit, 200);
-    if (args?.start) params.start = args.start;
-    if (args?.orderBy) params.orderBy = args.orderBy;
-    if (args?.orderByDir) params.orderByDir = args.orderByDir;
-    if (args?.publishedOnly) params.publishedOnly = args.publishedOnly;
-    if (args?.minimal) params.minimal = args.minimal;
+    setParam(params, 'search', args?.search);
+    setLimitedParam(params, 'limit', args?.limit, 200);
+    setParam(params, 'start', args?.start);
+    setParam(params, 'orderBy', args?.orderBy);
+    setParam(params, 'orderByDir', args?.orderByDir);
+    setParam(params, 'publishedOnly', args?.publishedOnly);
 
     const response = await client.v1.get('/contacts', { params });
+    const contacts = args?.fieldsOnly
+      ? normalizeContacts(response.data.contacts, args?.fields).map(contact => ({ id: contact.id, fields: contact.fields }))
+      : args?.minimal
+        ? normalizeContacts(response.data.contacts, args?.fields)
+        : response.data.contacts;
+
     return {
-      content: [{ type: 'text', text: `Found ${response.data.total} contacts:\n${JSON.stringify(response.data.contacts, null, 2)}` }],
+      content: [{ type: 'text', text: `Found ${response.data.total} contacts:\n${JSON.stringify(contacts, null, 2)}` }],
     };
   },
 

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -2,6 +2,17 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { MauticApiClient } from '../api/client.js';
 import type { ToolDefinition, ToolHandler } from '../types/index.js';
 
+function buildContactPayload(args: any) {
+  const { firstName, lastName, customFields, ...rest } = args;
+
+  return {
+    ...rest,
+    ...customFields,
+    ...(firstName !== undefined ? { firstname: firstName } : {}),
+    ...(lastName !== undefined ? { lastname: lastName } : {}),
+  };
+}
+
 export const toolDefinitions: ToolDefinition[] = [
   {
     name: 'create_contact',
@@ -92,7 +103,7 @@ export const toolDefinitions: ToolDefinition[] = [
 
 export const toolHandlers: Record<string, ToolHandler> = {
   async create_contact(client: MauticApiClient, args: any) {
-    const response = await client.v1.post('/contacts/new', args);
+    const response = await client.v1.post('/contacts/new', buildContactPayload(args));
     return {
       content: [{ type: 'text', text: `Contact created successfully:\n${JSON.stringify(response.data.contact, null, 2)}` }],
     };
@@ -100,7 +111,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   async update_contact(client: MauticApiClient, args: any) {
     const { id, ...updateData } = args;
-    const response = await client.v1.patch(`/contacts/${id}/edit`, updateData);
+    const response = await client.v1.patch(`/contacts/${id}/edit`, buildContactPayload(updateData));
     return {
       content: [{ type: 'text', text: `Contact updated successfully:\n${JSON.stringify(response.data.contact, null, 2)}` }],
     };

--- a/src/tools/segments.ts
+++ b/src/tools/segments.ts
@@ -1,5 +1,7 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { MauticApiClient } from '../api/client.js';
 import type { ToolDefinition, ToolHandler } from '../types/index.js';
+import { normalizeContacts, setLimitedParam, setParam } from './utils.js';
 
 export const toolDefinitions: ToolDefinition[] = [
   {
@@ -40,6 +42,9 @@ export const toolDefinitions: ToolDefinition[] = [
         segmentId: { type: 'number', description: 'Segment ID' },
         limit: { type: 'number', description: 'Number of results', maximum: 200 },
         start: { type: 'number', description: 'Starting offset' },
+        minimal: { type: 'boolean', description: 'Return normalized contact data instead of full Mautic metadata' },
+        fieldsOnly: { type: 'boolean', description: 'Return only normalized contact field values plus id' },
+        fields: { type: 'array', items: { type: 'string' }, description: 'Field aliases to include when minimal or fieldsOnly is true' },
       },
       required: ['segmentId'],
     },
@@ -49,10 +54,10 @@ export const toolDefinitions: ToolDefinition[] = [
 export const toolHandlers: Record<string, ToolHandler> = {
   async list_segments(client: MauticApiClient, args: any) {
     const params: any = {};
-    if (args?.search) params.search = args.search;
-    if (args?.limit) params.limit = Math.min(args.limit, 200);
-    if (args?.start) params.start = args.start;
-    if (args?.publishedOnly) params.publishedOnly = args.publishedOnly;
+    setParam(params, 'search', args?.search);
+    setLimitedParam(params, 'limit', args?.limit, 200);
+    setParam(params, 'start', args?.start);
+    setParam(params, 'publishedOnly', args?.publishedOnly);
 
     const response = await client.v1.get('/segments', { params });
     return {
@@ -68,14 +73,30 @@ export const toolHandlers: Record<string, ToolHandler> = {
   },
 
   async get_segment_contacts(client: MauticApiClient, args: any) {
-    const { segmentId, limit, start } = args;
+    const { segmentId, limit, start, minimal, fieldsOnly, fields } = args;
     const params: any = {};
-    if (limit) params.limit = Math.min(limit, 200);
-    if (start) params.start = start;
+    setLimitedParam(params, 'limit', limit, 200);
+    setParam(params, 'start', start);
 
-    const response = await client.v1.get(`/segments/${segmentId}/contacts`, { params });
+    const segmentsResponse = await client.v1.get('/segments', { params: { limit: 200 } });
+    const segments = Object.values(segmentsResponse.data.lists ?? {}) as any[];
+    const segment = segments.find((item: any) => Number(item.id) === Number(segmentId));
+
+    if (!segment?.alias) {
+      throw new McpError(ErrorCode.InvalidParams, `No segment alias found for segment ID ${segmentId}`);
+    }
+
+    params.search = `segment:${segment.alias}`;
+
+    const response = await client.v1.get('/contacts', { params });
+    const contacts = fieldsOnly
+      ? normalizeContacts(response.data.contacts, fields).map(contact => ({ id: contact.id, fields: contact.fields }))
+      : minimal
+        ? normalizeContacts(response.data.contacts, fields)
+        : response.data.contacts;
+
     return {
-      content: [{ type: 'text', text: `Found ${response.data.total} contacts in segment:\n${JSON.stringify(response.data.contacts, null, 2)}` }],
+      content: [{ type: 'text', text: `Found ${response.data.total} contacts in segment ${segment.alias}:\n${JSON.stringify(contacts, null, 2)}` }],
     };
   },
 };

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,0 +1,53 @@
+export function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null;
+}
+
+export function setParam(params: Record<string, unknown>, key: string, value: unknown): void {
+  if (hasValue(value)) {
+    params[key] = value;
+  }
+}
+
+export function setLimitedParam(params: Record<string, unknown>, key: string, value: unknown, max: number): void {
+  if (hasValue(value)) {
+    params[key] = Math.min(Number(value), max);
+  }
+}
+
+function pickFields(fields: Record<string, unknown>, aliases?: string[]): Record<string, unknown> {
+  if (!aliases?.length) {
+    return fields;
+  }
+
+  return Object.fromEntries(aliases.map(alias => [alias, fields[alias] ?? null]));
+}
+
+export function normalizeContact(contact: any, aliases?: string[]): Record<string, unknown> {
+  const fields = contact?.fields?.all ?? {};
+  const fieldValues = Object.fromEntries(
+    Object.entries(fields).map(([alias, field]: [string, any]) => [
+      alias,
+      field && typeof field === 'object' && 'value' in field ? field.value : field,
+    ]),
+  );
+
+  return {
+    id: contact?.id,
+    isPublished: contact?.isPublished,
+    dateAdded: contact?.dateAdded,
+    dateModified: contact?.dateModified,
+    dateIdentified: contact?.dateIdentified,
+    lastActive: contact?.lastActive,
+    points: contact?.points,
+    color: contact?.color,
+    fields: pickFields(fieldValues, aliases),
+    tags: contact?.tags,
+    companies: contact?.companies,
+    owner: contact?.owner,
+  };
+}
+
+export function normalizeContacts(contacts: any, aliases?: string[]): Record<string, unknown>[] {
+  const values = Array.isArray(contacts) ? contacts : Object.values(contacts ?? {});
+  return values.map(contact => normalizeContact(contact, aliases));
+}


### PR DESCRIPTION
## Overview

This updates the local Helio Mautic MCP fork for Mautic 6.0.7 contact workflows.

## Changes

- Fix `get_segment_contacts` by resolving segment ID to alias and searching contacts with `segment:<alias>`.
- Add compact contact output via `minimal`, `fieldsOnly`, and optional `fields` filters.
- Preserve explicit `0` and `false` query params in audited v1 tools.
- Fix contact tag add/remove to use the v1 contact edit endpoint.
- Add `remove_contact_tags`.
- Add shared tool helpers for query params and contact normalization.
- Bump local version to `0.1.1` and update changelog.

## Verification

- `npm run check` passes.
- `npm run build` passes.
- Live-tested segment `43`, returning 127 contacts.
- Live-tested compact `get_contact`, `search_contacts`, and `get_segment_contacts`.
- Live-tested add/remove tag on email; contact was returned to `tags: []`.