### PR TITLE
fix: map firstName/lastName and flatten customFields for contact tools

### DIFF
--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -2,6 +2,31 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { MauticApiClient } from '../api/client.js';
 import type { ToolDefinition, ToolHandler } from '../types/index.js';
 
+function normalizeContactPayload(args: any) {
+  const customFields = args?.customFields ?? {};
+  const payload = {
+    ...args,
+    ...customFields,
+  };
+
+  const normalizedFirstName = customFields.firstname ?? payload.firstname ?? args?.firstName;
+  const normalizedLastName = customFields.lastname ?? payload.lastname ?? args?.lastName;
+
+  delete payload.customFields;
+  delete payload.firstName;
+  delete payload.lastName;
+
+  if (normalizedFirstName !== undefined) {
+    payload.firstname = normalizedFirstName;
+  }
+
+  if (normalizedLastName !== undefined) {
+    payload.lastname = normalizedLastName;
+  }
+
+  return payload;
+}
+
 export const toolDefinitions: ToolDefinition[] = [
   {
     name: 'create_contact',
@@ -92,7 +117,7 @@ export const toolDefinitions: ToolDefinition[] = [
 
 export const toolHandlers: Record<string, ToolHandler> = {
   async create_contact(client: MauticApiClient, args: any) {
-    const response = await client.v1.post('/contacts/new', args);
+    const response = await client.v1.post('/contacts/new', normalizeContactPayload(args));
     return {
       content: [{ type: 'text', text: `Contact created successfully:\n${JSON.stringify(response.data.contact, null, 2)}` }],
     };
@@ -100,7 +125,7 @@ export const toolHandlers: Record<string, ToolHandler> = {
 
   async update_contact(client: MauticApiClient, args: any) {
     const { id, ...updateData } = args;
-    const response = await client.v1.patch(`/contacts/${id}/edit`, updateData);
+    const response = await client.v1.patch(`/contacts/${id}/edit`, normalizeContactPayload(updateData));
     return {
       content: [{ type: 'text', text: `Contact updated successfully:\n${JSON.stringify(response.data.contact, null, 2)}` }],
     };

--- a/tests/contact-field-mapping.test.mjs
+++ b/tests/contact-field-mapping.test.mjs
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toolHandlers } from '../build/tools/contacts.js';
+
+function makeClient() {
+  const calls = [];
+  return {
+    calls,
+    v1: {
+      async post(url, payload) {
+        calls.push({ method: 'post', url, payload });
+        return { data: { contact: payload } };
+      },
+      async patch(url, payload) {
+        calls.push({ method: 'patch', url, payload });
+        return { data: { contact: payload } };
+      },
+    },
+  };
+}
+
+test('create_contact maps camelCase names and flattens customFields into Mautic aliases', async () => {
+  const client = makeClient();
+
+  await toolHandlers.create_contact(client, {
+    email: 'test@example.com',
+    firstName: 'Hermes',
+    lastName: 'Agent',
+    company: 'Nous',
+    customFields: {
+      firstname: 'Override First',
+      lastname: 'Override Last',
+      favorite_color: 'blue',
+    },
+  });
+
+  assert.equal(client.calls.length, 1);
+  assert.deepEqual(client.calls[0], {
+    method: 'post',
+    url: '/contacts/new',
+    payload: {
+      email: 'test@example.com',
+      firstname: 'Override First',
+      lastname: 'Override Last',
+      company: 'Nous',
+      favorite_color: 'blue',
+    },
+  });
+});
+
+test('update_contact maps camelCase names and flattens customFields into Mautic aliases', async () => {
+  const client = makeClient();
+
+  await toolHandlers.update_contact(client, {
+    id: 42,
+    firstName: 'Hermes',
+    lastName: 'Agent',
+    customFields: {
+      firstname: 'Override First',
+      lastname: 'Override Last',
+      timezone: 'UTC',
+    },
+  });
+
+  assert.equal(client.calls.length, 1);
+  assert.deepEqual(client.calls[0], {
+    method: 'patch',
+    url: '/contacts/42/edit',
+    payload: {
+      firstname: 'Override First',
+      lastname: 'Override Last',
+      timezone: 'UTC',
+    },
+  });
+});


### PR DESCRIPTION
## Summary ##

This fixes contact field mapping for create_contact and update_contact.

The MCP schema accepts firstName and lastName, but the handlers were forwarding args directly to Mautic without translating them to the field aliases Mautic expects: firstname and lastname.

It also forwarded customFields as a nested object instead of flattening those values into the top-level payload.

## Problem ##
Before this change:

firstName / lastName were silently ignored by Mautic
customFields.firstname / customFields.lastname were not applied because customFields stayed nested

## Fix ##
map firstName -> firstname
map lastName -> lastname
flatten customFields into the top-level payload
remove the leftover firstName, lastName, and customFields keys before sending to Mautic

## Verification ##
Added a regression test covering both:

create_contact
update_contact

The test failed before the patch and passes after the patch.